### PR TITLE
Prepare for CPSW 4.3.1

### DIFF
--- a/yaml/1sb/FirmwareLoader.yaml
+++ b/yaml/1sb/FirmwareLoader.yaml
@@ -29,6 +29,8 @@ mmio: &mmio
 SRPProtoConfig: &SRPProtoConfig
   SRP:
     protocolVersion: SRP_UDP_V2
+    timeoutUS: 500000
+    retryCount: 50
   UDP:
     port: 8192
 

--- a/yaml/2sb/FirmwareLoader.yaml
+++ b/yaml/2sb/FirmwareLoader.yaml
@@ -29,6 +29,8 @@ mmio: &mmio
 SRPProtoConfig: &SRPProtoConfig
   SRP:
     protocolVersion: SRP_UDP_V2
+    timeoutUS: 500000
+    retryCount: 50
   UDP:
     port: 8192
 


### PR DESCRIPTION
Increase the SRP timeout and retry counts to avoid FirmwareLoader to failed when used on a CPU which runs IOC with CPSW 4.3.1 and the RT priorities set to new values, which can cause it to fail due to SRP responses to take longer that before.