### PR TITLE
Bug fix: fix a typo when printing an error message

### DIFF
--- a/ProgramFPGA.bash
+++ b/ProgramFPGA.bash
@@ -303,7 +303,7 @@ else
                 printf "buildroot-2019.08\n"
                 ARCH=buildroot-2019.08-x86_64
             else
-                prtinf "Buildroot version not supported!"
+                printf "Buildroot version not supported!"
                 exit
             fi
         fi


### PR DESCRIPTION
There is a typo when printing the error message when an unsupported buildroot version is found.