### PR TITLE
Treat 0xc return

### DIFF
--- a/ProgramFPGA.bash
+++ b/ProgramFPGA.bash
@@ -427,7 +427,7 @@ CPU_ETH=$($CPU_EXEC /sbin/ifconfig | grep -wB1 $CPU_IP | awk 'NR==1{print $1}' |
 if [ -z $CPU_ETH ]; then
     printf "Interface not found!\n"
     printf "\n"
-    printf "Aborting as the interace connected to the FPGA was not found.\n"
+    printf "Aborting as the interface connected to the FPGA was not found.\n"
     printf "Make sure an interface is configured correctly based on the shelfmanager's crateID\n"
     printf "\n"
     exit

--- a/ProgramFPGA.bash
+++ b/ProgramFPGA.bash
@@ -135,7 +135,7 @@ rebootFPGA()
         sleep $RETRAY_DELAY
         BSI_STATE=$(ipmitool -I lan -H $SHELFMANAGER -t $IPMB -b 0 -A NONE raw 0x34 0xF4 2> /dev/null | awk '{print $1}')
         EXIT_CODE=$?
-        if [ "$EXIT_CODE" -eq 0 ] && [ $BSI_STATE -eq 3 ]; then
+        if [ "$EXIT_CODE" -eq 0 ] && [ -n "$BSI_STATE" ] && [ $((16#$BSI_STATE)) -eq 3 ]; then
             DONE=1
             break
         fi

--- a/ProgramFPGA.bash
+++ b/ProgramFPGA.bash
@@ -424,7 +424,7 @@ printf "CPU IP address:                                   $CPU_IP\n"
 printf "Looking interface connected to the FPGA...        "
 CPU_ETH=$($CPU_EXEC /sbin/ifconfig | grep -wB1 $CPU_IP | awk 'NR==1{print $1}' | sed 's/://g')
 
-if [ -z $CPU_ETH ]; then
+if [ -z "$CPU_ETH" ]; then
     printf "Interface not found!\n"
     printf "\n"
     printf "Aborting as the interface connected to the FPGA was not found.\n"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 #  Release notes for ProgramFPGA bash script
+## pre-release:
+- Bug fix: The FPGA returned the state 0x0c and the script was treating this as
+  a number.
 
 ## R1.2.3: 2024-05-24 M. Skoufis 
 - Bug fix: Fix eth interface parsing


### PR DESCRIPTION
The FPGA returned the state 0x0c, and the script was treating this as a number.